### PR TITLE
ログイン画面がチラつくので修正

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -284,14 +284,10 @@ const onClickTeamLegend = (index: number) => {
 			class="authenticator"
 			v-else
 			:onSignIn="
-				async () => {
-					isAuthChecking = true;
-					try {
-						await fetchScores();
-						isAuthenticated = true;
-					} finally {
-						isAuthChecking = false;
-					}
+				() => {
+					isAuthenticated = true;
+					isAuthChecking = false;
+					fetchScores();
 				}
 			"
 		>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -285,12 +285,12 @@ const onClickTeamLegend = (index: number) => {
 			v-else
 			:onSignIn="
 				async () => {
-					isAuthChecking.value = true;
+					isAuthChecking = true;
 					try {
 						await fetchScores();
-						isAuthenticated.value = true;
+						isAuthenticated = true;
 					} finally {
-						isAuthChecking.value = false;
+						isAuthChecking = false;
 					}
 				}
 			"

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -155,7 +155,7 @@ const fetchScores = async () => {
   do {
     try {
       const result: any = await API.graphql(graphqlOperation(getAllScores, { 
-        limit: 100, // 一度に取得するスコアの数を指定
+        limit: 200, // 一度に取得するスコアの数を指定
         nextToken: nextToken 
       }));
 

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -27,7 +27,7 @@ const username = ref<string>('');
 const messageFromBench = ref<{message: string[], timestamp: number}>({message: [], timestamp: 0});
 const teamId = ref<number>(0);
 const leftPanelIsHidden = ref<boolean>(false);
-const isAuthChecking = ref<boolean>(true);
+const isAuthChecking = ref(true);
 
 watch(
 	() => scores.value,


### PR DESCRIPTION
https://github.com/cto-a/private-isu-ops/issues/67

「認証済み」以外に「認証中」のフラグをつくる。
認証中フラグがtrueのときはログイン画面もスコア画面も見せない。